### PR TITLE
Expand React lessons with state and componentization

### DIFF
--- a/aulas/react-componentizacao-avancada.html
+++ b/aulas/react-componentizacao-avancada.html
@@ -1,4 +1,4 @@
-<!-- ==================== Aula React 4 ==================== -->
+<!-- ==================== Aula React 4 (versão expandida) ==================== -->
 <article class="lesson-content">
   <h2>
     <i class="fab fa-react"></i> React – Componentização Avançada e Composição
@@ -6,18 +6,21 @@
 
   <div class="intro-box mb-5">
     <p>
-      Neste encontro vamos aprofundar as técnicas de componentização,
-      explorando diferentes formas de compor interfaces e evitar problemas
-      comuns como o <em>props drilling</em>.
+      Vamos aprofundar as técnicas de componentização, explorando diferentes
+      formas de compor interfaces e evitar problemas comuns como o
+      <em>props drilling</em>. O objetivo é deixar o código mais reutilizável,
+      organizado e fácil de manter.
     </p>
     <ul>
       <li>✅ Técnicas de composição e reutilização</li>
-      <li>✅ Uso avançado do <code>children</code></li>
-      <li>✅ Introdução ao problema do <em>props drilling</em></li>
-      <li>✅ Boas práticas de organização de componentes</li>
+      <li>✅ Uso avançado do <code>children</code> e <em>slots</em></li>
+      <li>✅ Introdução ao problema do <em>props drilling</em> e soluções</li>
+      <li>✅ Boas práticas de organização e manutenção</li>
+      <li>✅ Quiz e exercícios práticos com solução</li>
     </ul>
   </div>
 
+  <!-- 1. Técnicas de Composição -->
   <section class="mb-5">
     <h3 class="section-title with-icon">
       <i class="fas fa-layer-group"></i> 1. Técnicas de Composição
@@ -25,10 +28,15 @@
     <div class="card mb-4">
       <div class="card-body">
         <p>
-          Componentes menores podem ser combinados para formar estruturas mais
-          complexas. Essa abordagem facilita o reuso e a leitura do código.
+          Em vez de criar um componente gigante, podemos quebrá-lo em peças
+          menores e combiná-las. Isso facilita testes, reuso e clareza do
+          código.
         </p>
-        <pre><code class="language-jsx">function Toolbar() {
+        <pre><code class="language-jsx">function Botao({ texto }) {
+  return &lt;button&gt;{texto}&lt;/button&gt;;
+}
+
+function Toolbar() {
   return (
     &lt;div className="toolbar"&gt;
       &lt;Botao texto="Salvar" /&gt;
@@ -36,10 +44,36 @@
     &lt;/div&gt;
   );
 }</code></pre>
+
+        <h4 class="mt-4 mb-2">1.1 Composição com múltiplos componentes</h4>
+        <pre><code class="language-jsx">function Card({ titulo, conteudo, acoes }) {
+  return (
+    &lt;div className="card"&gt;
+      &lt;h3&gt;{titulo}&lt;/h3&gt;
+      &lt;p&gt;{conteudo}&lt;/p&gt;
+      &lt;div className="acoes"&gt;{acoes}&lt;/div&gt;
+    &lt;/div&gt;
+  );
+}
+
+export default function App() {
+  return (
+    &lt;Card
+      titulo="Bem-vindo"
+      conteudo="Este é um card reutilizável."
+      acoes={&lt;button&gt;OK&lt;/button&gt;}
+    /&gt;
+  );
+}</code></pre>
+        <div class="alert alert-info mt-3">
+          <strong>Dica:</strong> Podemos passar JSX como props (ex.:
+          <code>acoes</code>) para criar layouts flexíveis.
+        </div>
       </div>
     </div>
   </section>
 
+  <!-- 2. Uso do children -->
   <section class="mb-5">
     <h3 class="section-title with-icon">
       <i class="fas fa-box-open"></i> 2. Uso do <code>children</code>
@@ -47,8 +81,9 @@
     <div class="card mb-4">
       <div class="card-body">
         <p>
-          A prop especial <code>children</code> permite que um componente envolva
-          elementos arbitrários, tornando-o altamente reutilizável.
+          <code>children</code> é uma prop especial que recebe tudo que estiver
+          entre as tags de abertura e fechamento do componente. Isso permite
+          criar "containers" reutilizáveis.
         </p>
         <pre><code class="language-jsx">function Painel({ children }) {
   return &lt;section className="painel"&gt;{children}&lt;/section&gt;;
@@ -62,10 +97,33 @@ export default function App() {
     &lt;/Painel&gt;
   );
 }</code></pre>
+
+        <h4 class="mt-4 mb-2">2.1 Children com múltiplas áreas (slots)</h4>
+        <pre><code class="language-jsx">function Painel({ cabecalho, rodape, children }) {
+  return (
+    &lt;section className="painel"&gt;
+      &lt;header&gt;{cabecalho}&lt;/header&gt;
+      &lt;div&gt;{children}&lt;/div&gt;
+      &lt;footer&gt;{rodape}&lt;/footer&gt;
+    &lt;/section&gt;
+  );
+}
+
+export default function App() {
+  return (
+    &lt;Painel
+      cabecalho={&lt;h2&gt;Título&lt;/h2&gt;}
+      rodape={&lt;small&gt;Rodapé&lt;/small&gt;}
+    &gt;
+      &lt;p&gt;Conteúdo do painel&lt;/p&gt;
+    &lt;/Painel&gt;
+  );
+}</code></pre>
       </div>
     </div>
   </section>
 
+  <!-- 3. Props Drilling -->
   <section class="mb-5">
     <h3 class="section-title with-icon">
       <i class="fas fa-share"></i> 3. Props Drilling
@@ -73,18 +131,34 @@ export default function App() {
     <div class="card mb-4">
       <div class="card-body">
         <p>
-          O <em>props drilling</em> ocorre quando uma prop precisa ser passada por
-          muitos níveis de componentes apenas para alcançar um componente mais
-          interno. Isso torna o código difícil de manter.
+          O <em>props drilling</em> ocorre quando passamos props por vários
+          níveis de componentes apenas para que cheguem ao destino final.
         </p>
+        <pre><code class="language-jsx">function Nivel3({ mensagem }) {
+  return &lt;p&gt;Mensagem: {mensagem}&lt;/p&gt;;
+}
+
+function Nivel2({ mensagem }) {
+  return &lt;Nivel3 mensagem={mensagem} /&gt;;
+}
+
+function Nivel1({ mensagem }) {
+  return &lt;Nivel2 mensagem={mensagem} /&gt;;
+}
+
+export default function App() {
+  return &lt;Nivel1 mensagem="Olá!" /&gt;;
+}</code></pre>
         <p>
-          Uma alternativa é utilizar o <code>Context API</code> ou bibliotecas de
-          gerenciamento de estado, que veremos em aulas futuras.
+          Isso funciona, mas é difícil de manter se muitos níveis precisarem da
+          prop. A solução é usar <strong>Context API</strong> ou um gerenciador
+          de estado.
         </p>
       </div>
     </div>
   </section>
 
+  <!-- 4. Boas Práticas -->
   <section class="mb-5">
     <h3 class="section-title with-icon">
       <i class="fas fa-check-double"></i> 4. Boas Práticas
@@ -92,14 +166,22 @@ export default function App() {
     <div class="card mb-4">
       <div class="card-body">
         <ul>
-          <li>Mantenha os componentes pequenos e com uma responsabilidade clara.</li>
-          <li>Organize os arquivos em pastas que reflitam a estrutura da aplicação.</li>
-          <li>Prefira composição em vez de herança.</li>
+          <li>Componentes pequenos e com responsabilidade única.</li>
+          <li>
+            Organizar em pastas por <em>feature</em> ou tipo de componente.
+          </li>
+          <li>Usar composição ao invés de herança.</li>
+          <li>
+            Evitar <em>props drilling</em> excessivo (use Context quando
+            necessário).
+          </li>
+          <li>Nomear componentes e props de forma clara.</li>
         </ul>
       </div>
     </div>
   </section>
 
+  <!-- 5. Resumo -->
   <section class="mb-5">
     <h3 class="section-title with-icon">
       <i class="fas fa-check-circle"></i> 5. Resumo
@@ -107,36 +189,150 @@ export default function App() {
     <div class="card mb-4">
       <div class="card-body">
         <ul>
-          <li>Componentes podem ser combinados para formar interfaces complexas.</li>
-          <li><code>children</code> torna componentes mais flexíveis.</li>
-          <li>Evite o <em>props drilling</em> para manter o código limpo.</li>
+          <li>
+            Quebre interfaces grandes em componentes menores e reutilizáveis.
+          </li>
+          <li>
+            Use <code>children</code> e props JSX para compor layouts flexíveis.
+          </li>
+          <li>
+            Evite <em>props drilling</em> — prefira Context API ou estados
+            globais quando necessário.
+          </li>
         </ul>
       </div>
     </div>
   </section>
 
+  <!-- 6. Testes rápidos -->
   <section class="mb-5">
     <h3 class="section-title with-icon">
-      <i class="fas fa-chalkboard-teacher"></i> 6. Exercícios
+      <i class="fas fa-clipboard-check"></i> 6. Testes Rápidos (Quiz)
+    </h3>
+    <div class="card mb-4">
+      <div class="card-body">
+        <ol>
+          <li>O que é <em>props drilling</em>?</li>
+          <li>Qual prop especial recebe elementos filhos no JSX?</li>
+          <li>Qual é mais recomendado: composição ou herança no React?</li>
+          <li>
+            Verdadeiro ou falso: você pode passar JSX como valor de uma prop
+            normal.
+          </li>
+          <li>Qual é uma solução comum para evitar <em>props drilling</em>?</li>
+        </ol>
+        <details class="solucao">
+          <summary>Mostrar gabarito</summary>
+          <ol>
+            <li>Passar props por muitos níveis até chegar ao destino.</li>
+            <li><code>children</code></li>
+            <li>Composição</li>
+            <li>Verdadeiro</li>
+            <li>Context API ou gerenciador de estado</li>
+          </ol>
+        </details>
+      </div>
+    </div>
+  </section>
+
+  <!-- 7. Exercícios -->
+  <section class="mb-5">
+    <h3 class="section-title with-icon">
+      <i class="fas fa-chalkboard-teacher"></i> 7. Exercícios
     </h3>
 
     <div class="desafio">
       <h4>Exercício 1: Painel Reutilizável</h4>
-      <p><strong>Objetivo:</strong> criar um componente <code>Painel</code> que utilize <code>children</code>.</p>
+      <p>
+        <strong>Objetivo:</strong> criar um componente <code>Painel</code> que
+        utilize <code>children</code>.
+      </p>
       <ol>
-        <li>Implemente o componente <code>Painel</code> mostrado acima.</li>
+        <li>Implemente o <code>Painel</code> com uma borda e padding.</li>
         <li>Utilize-o para envolver diferentes blocos de conteúdo.</li>
       </ol>
+      <details class="solucao">
+        <summary>Mostrar solução</summary>
+        <pre><code class="language-jsx">function Painel({ children }) {
+  const estilo = { border: '1px solid #ccc', padding: '12px', borderRadius: '8px' };
+  return &lt;section style={estilo}&gt;{children}&lt;/section&gt;;
+}
+
+export default function App() {
+  return (
+    &lt;&gt;
+      &lt;Painel&gt;&lt;h2&gt;Título 1&lt;/h2&gt;&lt;p&gt;Conteúdo 1&lt;/p&gt;&lt;/Painel&gt;
+      &lt;Painel&gt;&lt;h2&gt;Título 2&lt;/h2&gt;&lt;p&gt;Conteúdo 2&lt;/p&gt;&lt;/Painel&gt;
+    &lt;/&gt;
+  );
+}</code></pre>
+      </details>
     </div>
 
     <div class="desafio">
       <h4>Exercício 2: Evitando Props Drilling</h4>
-      <p><strong>Objetivo:</strong> perceber o problema de passar props em cadeia.</p>
+      <p>
+        <strong>Objetivo:</strong> perceber o problema de passar props em
+        cadeia.
+      </p>
       <ol>
         <li>Crie três componentes aninhados.</li>
-        <li>Passe uma prop do primeiro até o último componente.</li>
-        <li>Reflita sobre como o Context API pode simplificar esse processo.</li>
+        <li>Passe uma prop do primeiro até o último.</li>
+        <li>Reflita sobre como o Context API simplificaria o processo.</li>
       </ol>
+      <details class="solucao">
+        <summary>Mostrar solução</summary>
+        <pre><code class="language-jsx">function Neto({ mensagem }) {
+  return &lt;p&gt;Mensagem recebida: {mensagem}&lt;/p&gt;;
+}
+function Filho({ mensagem }) {
+  return &lt;Neto mensagem={mensagem} /&gt;;
+}
+function Pai({ mensagem }) {
+  return &lt;Filho mensagem={mensagem} /&gt;;
+}
+export default function App() {
+  return &lt;Pai mensagem="Olá do Pai!" /&gt;;
+}</code></pre>
+      </details>
+    </div>
+
+    <div class="desafio">
+      <h4>Exercício 3: Card com Slots</h4>
+      <p>
+        <strong>Objetivo:</strong> criar um <code>Card</code> com áreas de
+        cabeçalho, conteúdo e rodapé.
+      </p>
+      <ol>
+        <li>
+          Receba <code>cabecalho</code>, <code>rodape</code> e
+          <code>children</code> como props.
+        </li>
+        <li>Monte o layout do card usando essas áreas.</li>
+      </ol>
+      <details class="solucao">
+        <summary>Mostrar solução</summary>
+        <pre><code class="language-jsx">function Card({ cabecalho, rodape, children }) {
+  return (
+    &lt;div className="card"&gt;
+      &lt;header&gt;{cabecalho}&lt;/header&gt;
+      &lt;main&gt;{children}&lt;/main&gt;
+      &lt;footer&gt;{rodape}&lt;/footer&gt;
+    &lt;/div&gt;
+  );
+}
+
+export default function App() {
+  return (
+    &lt;Card
+      cabecalho={&lt;h2&gt;Título do Card&lt;/h2&gt;}
+      rodape={&lt;small&gt;Rodapé&lt;/small&gt;}
+    &gt;
+      &lt;p&gt;Conteúdo central do card&lt;/p&gt;
+    &lt;/Card&gt;
+  );
+}</code></pre>
+      </details>
     </div>
   </section>
 </article>

--- a/aulas/react-componentizacao-avancada.html
+++ b/aulas/react-componentizacao-avancada.html
@@ -1,0 +1,142 @@
+<!-- ==================== Aula React 4 ==================== -->
+<article class="lesson-content">
+  <h2>
+    <i class="fab fa-react"></i> React – Componentização Avançada e Composição
+  </h2>
+
+  <div class="intro-box mb-5">
+    <p>
+      Neste encontro vamos aprofundar as técnicas de componentização,
+      explorando diferentes formas de compor interfaces e evitar problemas
+      comuns como o <em>props drilling</em>.
+    </p>
+    <ul>
+      <li>✅ Técnicas de composição e reutilização</li>
+      <li>✅ Uso avançado do <code>children</code></li>
+      <li>✅ Introdução ao problema do <em>props drilling</em></li>
+      <li>✅ Boas práticas de organização de componentes</li>
+    </ul>
+  </div>
+
+  <section class="mb-5">
+    <h3 class="section-title with-icon">
+      <i class="fas fa-layer-group"></i> 1. Técnicas de Composição
+    </h3>
+    <div class="card mb-4">
+      <div class="card-body">
+        <p>
+          Componentes menores podem ser combinados para formar estruturas mais
+          complexas. Essa abordagem facilita o reuso e a leitura do código.
+        </p>
+        <pre><code class="language-jsx">function Toolbar() {
+  return (
+    &lt;div className="toolbar"&gt;
+      &lt;Botao texto="Salvar" /&gt;
+      &lt;Botao texto="Cancelar" /&gt;
+    &lt;/div&gt;
+  );
+}</code></pre>
+      </div>
+    </div>
+  </section>
+
+  <section class="mb-5">
+    <h3 class="section-title with-icon">
+      <i class="fas fa-box-open"></i> 2. Uso do <code>children</code>
+    </h3>
+    <div class="card mb-4">
+      <div class="card-body">
+        <p>
+          A prop especial <code>children</code> permite que um componente envolva
+          elementos arbitrários, tornando-o altamente reutilizável.
+        </p>
+        <pre><code class="language-jsx">function Painel({ children }) {
+  return &lt;section className="painel"&gt;{children}&lt;/section&gt;;
+}
+
+export default function App() {
+  return (
+    &lt;Painel&gt;
+      &lt;h2&gt;Título&lt;/h2&gt;
+      &lt;p&gt;Conteúdo do painel&lt;/p&gt;
+    &lt;/Painel&gt;
+  );
+}</code></pre>
+      </div>
+    </div>
+  </section>
+
+  <section class="mb-5">
+    <h3 class="section-title with-icon">
+      <i class="fas fa-share"></i> 3. Props Drilling
+    </h3>
+    <div class="card mb-4">
+      <div class="card-body">
+        <p>
+          O <em>props drilling</em> ocorre quando uma prop precisa ser passada por
+          muitos níveis de componentes apenas para alcançar um componente mais
+          interno. Isso torna o código difícil de manter.
+        </p>
+        <p>
+          Uma alternativa é utilizar o <code>Context API</code> ou bibliotecas de
+          gerenciamento de estado, que veremos em aulas futuras.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section class="mb-5">
+    <h3 class="section-title with-icon">
+      <i class="fas fa-check-double"></i> 4. Boas Práticas
+    </h3>
+    <div class="card mb-4">
+      <div class="card-body">
+        <ul>
+          <li>Mantenha os componentes pequenos e com uma responsabilidade clara.</li>
+          <li>Organize os arquivos em pastas que reflitam a estrutura da aplicação.</li>
+          <li>Prefira composição em vez de herança.</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <section class="mb-5">
+    <h3 class="section-title with-icon">
+      <i class="fas fa-check-circle"></i> 5. Resumo
+    </h3>
+    <div class="card mb-4">
+      <div class="card-body">
+        <ul>
+          <li>Componentes podem ser combinados para formar interfaces complexas.</li>
+          <li><code>children</code> torna componentes mais flexíveis.</li>
+          <li>Evite o <em>props drilling</em> para manter o código limpo.</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <section class="mb-5">
+    <h3 class="section-title with-icon">
+      <i class="fas fa-chalkboard-teacher"></i> 6. Exercícios
+    </h3>
+
+    <div class="desafio">
+      <h4>Exercício 1: Painel Reutilizável</h4>
+      <p><strong>Objetivo:</strong> criar um componente <code>Painel</code> que utilize <code>children</code>.</p>
+      <ol>
+        <li>Implemente o componente <code>Painel</code> mostrado acima.</li>
+        <li>Utilize-o para envolver diferentes blocos de conteúdo.</li>
+      </ol>
+    </div>
+
+    <div class="desafio">
+      <h4>Exercício 2: Evitando Props Drilling</h4>
+      <p><strong>Objetivo:</strong> perceber o problema de passar props em cadeia.</p>
+      <ol>
+        <li>Crie três componentes aninhados.</li>
+        <li>Passe uma prop do primeiro até o último componente.</li>
+        <li>Reflita sobre como o Context API pode simplificar esse processo.</li>
+      </ol>
+    </div>
+  </section>
+</article>

--- a/aulas/react-estado-hooks-basicos.html
+++ b/aulas/react-estado-hooks-basicos.html
@@ -1,0 +1,134 @@
+<!-- ==================== Aula React 3 ==================== -->
+<article class="lesson-content">
+  <h2>
+    <i class="fab fa-react"></i> React – Estado e Hooks Básicos
+  </h2>
+
+  <div class="intro-box mb-5">
+    <p>
+      Nesta aula veremos como gerenciar dados internos dos componentes com
+      <strong>useState</strong> e como executar efeitos colaterais utilizando
+      <strong>useEffect</strong>.
+    </p>
+    <ul>
+      <li>✅ Conceito de estado no React</li>
+      <li>✅ Atualização de valores com <code>useState</code></li>
+      <li>✅ Efeitos e ciclo de vida com <code>useEffect</code></li>
+    </ul>
+  </div>
+
+  <section class="mb-5">
+    <h3 class="section-title with-icon">
+      <i class="fas fa-database"></i> 1. O que é Estado?
+    </h3>
+    <div class="card mb-4">
+      <div class="card-body">
+        <p>
+          Estado é o conjunto de dados que representa a situação atual de um
+          componente. Quando o estado muda, o React renderiza novamente o
+          componente exibindo os novos valores.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section class="mb-5">
+    <h3 class="section-title with-icon">
+      <i class="fas fa-toggle-on"></i> 2. Gerenciando dados com <code>useState</code>
+    </h3>
+    <div class="card mb-4">
+      <div class="card-body">
+        <p>
+          O hook <code>useState</code> retorna um valor de estado e uma função para
+          atualizá-lo. Sempre que chamamos essa função, o componente é
+          re-renderizado.
+        </p>
+        <pre><code class="language-jsx">import { useState } from 'react';
+
+export default function Contador() {
+  const [valor, setValor] = useState(0);
+
+  function incrementar() {
+    setValor(valor + 1);
+  }
+
+  return (
+    &lt;div&gt;
+      &lt;p&gt;Valor: {valor}&lt;/p&gt;
+      &lt;button onClick={incrementar}&gt;Adicionar&lt;/button&gt;
+    &lt;/div&gt;
+  );
+}
+</code></pre>
+      </div>
+    </div>
+  </section>
+
+  <section class="mb-5">
+    <h3 class="section-title with-icon">
+      <i class="fas fa-sync"></i> 3. Efeitos com <code>useEffect</code>
+    </h3>
+    <div class="card mb-4">
+      <div class="card-body">
+        <p>
+          O hook <code>useEffect</code> permite executar código em resposta a
+          mudanças de estado ou props. É ideal para buscar dados em APIs ou
+          sincronizar o componente com APIs externas.
+        </p>
+        <pre><code class="language-jsx">import { useState, useEffect } from 'react';
+
+export default function Relogio() {
+  const [hora, setHora] = useState(new Date());
+
+  useEffect(() =&gt; {
+    const id = setInterval(() =&gt; setHora(new Date()), 1000);
+    return () =&gt; clearInterval(id);
+  }, []);
+
+  return &lt;p&gt;{hora.toLocaleTimeString()}&lt;/p&gt;;
+}
+</code></pre>
+      </div>
+    </div>
+  </section>
+
+  <section class="mb-5">
+    <h3 class="section-title with-icon">
+      <i class="fas fa-check-circle"></i> 4. Resumo
+    </h3>
+    <div class="card mb-4">
+      <div class="card-body">
+        <ul>
+          <li><code>useState</code> controla dados mutáveis do componente.</li>
+          <li><code>useEffect</code> executa efeitos colaterais e permite
+            sincronizar o componente com o exterior.</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <section class="mb-5">
+    <h3 class="section-title with-icon">
+      <i class="fas fa-chalkboard-teacher"></i> 5. Exercícios
+    </h3>
+
+    <div class="desafio">
+      <h4>Exercício 1: Contador</h4>
+      <p><strong>Objetivo:</strong> criar um contador que aumente o valor ao clicar em um botão.</p>
+      <ol>
+        <li>Implemente o componente <code>Contador</code> mostrado acima.</li>
+        <li>Adicione um segundo botão para diminuir o valor.</li>
+        <li>Exiba o valor atual na tela.</li>
+      </ol>
+    </div>
+
+    <div class="desafio">
+      <h4>Exercício 2: Relógio</h4>
+      <p><strong>Objetivo:</strong> exibir a hora atualizada a cada segundo.</p>
+      <ol>
+        <li>Use o componente <code>Relogio</code> mostrado anteriormente.</li>
+        <li>Altere o formato da hora utilizando <code>toLocaleTimeString</code>.</li>
+      </ol>
+    </div>
+  </section>
+</article>

--- a/aulas/react-estado-hooks-basicos.html
+++ b/aulas/react-estado-hooks-basicos.html
@@ -1,8 +1,6 @@
-<!-- ==================== Aula React 3 ==================== -->
+<!-- ==================== Aula React 3 (versão expandida) ==================== -->
 <article class="lesson-content">
-  <h2>
-    <i class="fab fa-react"></i> React – Estado e Hooks Básicos
-  </h2>
+  <h2><i class="fab fa-react"></i> React – Estado e Hooks Básicos</h2>
 
   <div class="intro-box mb-5">
     <p>
@@ -12,11 +10,25 @@
     </p>
     <ul>
       <li>✅ Conceito de estado no React</li>
-      <li>✅ Atualização de valores com <code>useState</code></li>
-      <li>✅ Efeitos e ciclo de vida com <code>useEffect</code></li>
+      <li>✅ Regras dos Hooks e boas práticas</li>
+      <li>
+        ✅ Atualização de valores com <code>useState</code> (inclui atualização
+        funcional)
+      </li>
+      <li>
+        ✅ Efeitos e ciclo de vida com <code>useEffect</code> (dependências e
+        limpeza)
+      </li>
+      <li>
+        ✅ Padrões comuns: inputs controlados, timers, fetch e <em>cleanup</em>
+      </li>
+      <li>
+        ✅ Testes rápidos (quiz) e exercícios com <strong>solução</strong>
+      </li>
     </ul>
   </div>
 
+  <!-- 1. O que é Estado -->
   <section class="mb-5">
     <h3 class="section-title with-icon">
       <i class="fas fa-database"></i> 1. O que é Estado?
@@ -24,24 +36,81 @@
     <div class="card mb-4">
       <div class="card-body">
         <p>
-          Estado é o conjunto de dados que representa a situação atual de um
-          componente. Quando o estado muda, o React renderiza novamente o
-          componente exibindo os novos valores.
+          <strong>Estado</strong> é o conjunto de dados que representa a
+          situação atual de um componente. Quando o estado muda, o React
+          <em>re-renderiza</em> o componente exibindo os novos valores.
         </p>
+        <ul>
+          <li>
+            Estado vive <strong>dentro</strong> do componente (não é global).
+          </li>
+          <li>
+            O React compara a nova árvore de JSX e atualiza a tela de forma
+            eficiente.
+          </li>
+          <li>Estados diferentes ⇒ renderizações diferentes.</li>
+        </ul>
+        <div class="alert alert-info mt-3">
+          <strong>Dica mental:</strong> pense no JSX como uma função do estado:
+          <code>UI = f(estado)</code>.
+        </div>
       </div>
     </div>
   </section>
 
+  <!-- 2. Regras dos Hooks -->
   <section class="mb-5">
     <h3 class="section-title with-icon">
-      <i class="fas fa-toggle-on"></i> 2. Gerenciando dados com <code>useState</code>
+      <i class="fas fa-ruler"></i> 2. Regras dos Hooks
     </h3>
     <div class="card mb-4">
       <div class="card-body">
+        <ul>
+          <li>
+            Chame Hooks <strong>apenas no nível superior</strong> do componente
+            (nunca dentro de <code>if</code>, <code>for</code> ou funções
+            comuns).
+          </li>
+          <li>
+            Chame Hooks <strong>apenas</strong> dentro de componentes de função
+            ou de <em>custom hooks</em>.
+          </li>
+          <li>
+            A ordem das chamadas de Hooks <strong>não pode mudar</strong> entre
+            renderizações.
+          </li>
+        </ul>
+        <pre><code class="language-jsx">// ✅ Correto
+export default function Exemplo() {
+  const [x, setX] = useState(0);
+  // ...
+  return &lt;div /&gt;;
+}
+
+// ❌ Errado (hook dentro de condicional)
+export default function Erro() {
+  if (Math.random() &gt; 0.5) {
+    const [x, setX] = useState(0); // NÃO FAÇA ISSO
+  }
+  return &lt;div /&gt;;
+}</code></pre>
+      </div>
+    </div>
+  </section>
+
+  <!-- 3. useState (básico e avançado) -->
+  <section class="mb-5">
+    <h3 class="section-title with-icon">
+      <i class="fas fa-toggle-on"></i> 3. Gerenciando dados com
+      <code>useState</code>
+    </h3>
+
+    <div class="card mb-4">
+      <div class="card-body">
         <p>
-          O hook <code>useState</code> retorna um valor de estado e uma função para
-          atualizá-lo. Sempre que chamamos essa função, o componente é
-          re-renderizado.
+          O hook <code>useState</code> retorna um valor de estado e uma função
+          para atualizá-lo. Sempre que a função de atualização é chamada, o
+          componente é re-renderizado.
         </p>
         <pre><code class="language-jsx">import { useState } from 'react';
 
@@ -49,7 +118,7 @@ export default function Contador() {
   const [valor, setValor] = useState(0);
 
   function incrementar() {
-    setValor(valor + 1);
+    setValor(valor + 1); // atualização baseada no valor atual
   }
 
   return (
@@ -58,23 +127,289 @@ export default function Contador() {
       &lt;button onClick={incrementar}&gt;Adicionar&lt;/button&gt;
     &lt;/div&gt;
   );
-}
+}</code></pre>
+
+        <h4 class="mt-4 mb-2">
+          3.1 Atualização funcional (evita “estado antigo”)
+        </h4>
+        <p>
+          Quando a nova atualização depende do <strong>estado anterior</strong>,
+          use a forma funcional:
+        </p>
+        <pre><code class="language-jsx">setValor(prev =&gt; prev + 1); // seguro mesmo com várias atualizações seguidas</code></pre>
+
+        <h4 class="mt-3 mb-2">
+          3.2 Objetos e arrays no estado (imutabilidade)
+        </h4>
+        <p>Não modifique direto. Crie uma nova cópia ao atualizar.</p>
+        <pre><code class="language-jsx">const [aluno, setAluno] = useState({ nome: 'Ana', pontos: 0 });
+
+// ❌ NÃO faça:
+// aluno.pontos = aluno.pontos + 1; setAluno(aluno);
+
+// ✅ Faça:
+setAluno(prev =&gt; ({ ...prev, pontos: prev.pontos + 1 }));
+
+const [lista, setLista] = useState(['A', 'B']);
+setLista(prev =&gt; [...prev, 'C']); // adiciona sem mutar
 </code></pre>
+
+        <h4 class="mt-3 mb-2">3.3 Inputs controlados (estado &lt;→ input)</h4>
+        <pre><code class="language-jsx">function FormNome() {
+  const [nome, setNome] = useState('');
+
+  return (
+    &lt;div&gt;
+      &lt;input value={nome} onChange={e =&gt; setNome(e.target.value)} placeholder="Seu nome" /&gt;
+      &lt;p&gt;Olá, {nome || 'Visitante'}!&lt;/p&gt;
+    &lt;/div&gt;
+  );
+}</code></pre>
       </div>
     </div>
   </section>
 
+  <!-- 4. useEffect -->
   <section class="mb-5">
     <h3 class="section-title with-icon">
-      <i class="fas fa-sync"></i> 3. Efeitos com <code>useEffect</code>
+      <i class="fas fa-sync"></i> 4. Efeitos com <code>useEffect</code>
     </h3>
+
     <div class="card mb-4">
       <div class="card-body">
         <p>
-          O hook <code>useEffect</code> permite executar código em resposta a
-          mudanças de estado ou props. É ideal para buscar dados em APIs ou
-          sincronizar o componente com APIs externas.
+          <code>useEffect</code> executa efeitos colaterais: chamar APIs,
+          configurar timers, <em>listeners</em>, sincronizar com armazenamento,
+          etc. A assinatura é <code>useEffect(callback, deps?)</code>.
         </p>
+
+        <h4 class="mt-2 mb-2">4.1 Padrões de dependência</h4>
+        <ul>
+          <li>
+            <strong>Sem array</strong>: roda em toda renderização (cuidado!).
+          </li>
+          <li>
+            <strong>Array vazio []</strong>: roda uma vez no <em>mount</em> e
+            limpa no <em>unmount</em>.
+          </li>
+          <li>
+            <strong>[x, y]</strong>: roda quando <code>x</code> ou
+            <code>y</code> mudarem.
+          </li>
+        </ul>
+
+        <pre><code class="language-jsx">import { useState, useEffect } from 'react';
+
+export default function Relogio() {
+  const [hora, setHora] = useState(new Date());
+
+  useEffect(() =&gt; {
+    const id = setInterval(() =&gt; setHora(new Date()), 1000);
+    return () =&gt; clearInterval(id); // limpeza no unmount
+  }, []); // roda uma vez
+
+  return &lt;p&gt;{hora.toLocaleTimeString()}&lt;/p&gt;;
+}</code></pre>
+
+        <h4 class="mt-3 mb-2">
+          4.2 Exemplo: escutar eventos do teclado (com limpeza)
+        </h4>
+        <pre><code class="language-jsx">function Teclado() {
+  const [ultimaTecla, setUltimaTecla] = useState('');
+
+  useEffect(() =&gt; {
+    const onKey = (e) =&gt; setUltimaTecla(e.key);
+    window.addEventListener('keydown', onKey);
+    return () =&gt; window.removeEventListener('keydown', onKey);
+  }, []);
+
+  return &lt;p&gt;Última tecla: {ultimaTecla}&lt;/p&gt;;
+}</code></pre>
+
+        <h4 class="mt-3 mb-2">
+          4.3 Exemplo: busca em API (com carregando/erro)
+        </h4>
+        <pre><code class="language-jsx">function Usuarios() {
+  const [dados, setDados] = useState([]);
+  const [carregando, setCarregando] = useState(true);
+  const [erro, setErro] = useState(null);
+
+  useEffect(() =&gt; {
+    let ativo = true;
+    fetch('https://jsonplaceholder.typicode.com/users')
+      .then(r =&gt; r.json())
+      .then(json =&gt; { if (ativo) { setDados(json); setCarregando(false); }})
+      .catch(e =&gt; { if (ativo) { setErro(e.message); setCarregando(false); }});
+    return () =&gt; { ativo = false; };
+  }, []);
+
+  if (carregando) return &lt;p&gt;Carregando...&lt;/p&gt;;
+  if (erro) return &lt;p&gt;Erro: {erro}&lt;/p&gt;;
+
+  return (
+    &lt;ul&gt;
+      {dados.map(u =&gt; &lt;li key={u.id}&gt;{u.name}&lt;/li&gt;)}
+    &lt;/ul&gt;
+  );
+}</code></pre>
+
+        <div class="alert alert-warning mt-3">
+          <strong>Cuidados comuns:</strong> não chame <code>setState</code> em
+          loop dentro do render; limpe timers e <em>listeners</em>; inclua todas
+          as dependências usadas dentro do efeito no array de dependências.
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- 5. Resumo -->
+  <section class="mb-5">
+    <h3 class="section-title with-icon">
+      <i class="fas fa-check-circle"></i> 5. Resumo
+    </h3>
+    <div class="card mb-4">
+      <div class="card-body">
+        <ul>
+          <li>
+            <code>useState</code>: controla dados mutáveis do componente; use
+            atualização funcional quando depender do valor anterior.
+          </li>
+          <li>
+            <code>useEffect</code>: executa efeitos colaterais; entenda
+            <strong>dependências</strong> e a função de
+            <strong>limpeza</strong>.
+          </li>
+          <li>
+            <strong>Imutabilidade</strong>: crie novas cópias de objetos/arrays
+            ao atualizar.
+          </li>
+          <li>
+            <strong>Regras dos Hooks</strong>: topo do componente e mesma ordem
+            sempre.
+          </li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <!-- 6. Testes rápidos (quiz) -->
+  <section class="mb-5">
+    <h3 class="section-title with-icon">
+      <i class="fas fa-clipboard-check"></i> 6. Testes Rápidos (Quiz)
+    </h3>
+    <div class="card mb-4">
+      <div class="card-body">
+        <ol>
+          <li class="mb-3">
+            Onde podemos chamar hooks como <code>useState</code> e
+            <code>useEffect</code>?
+            <div>
+              a) Em qualquer função JS &nbsp; b) Em componentes de função e
+              custom hooks &nbsp; c) Dentro de <code>if</code> &nbsp; d) Em
+              classes
+            </div>
+          </li>
+          <li class="mb-3">
+            Qual forma é mais segura quando a atualização depende do valor
+            anterior?
+            <div>
+              a) <code>setX(x + 1)</code> &nbsp; b)
+              <code>setX(prev =&gt; prev + 1)</code>
+            </div>
+          </li>
+          <li class="mb-3">
+            O que faz o <code>return</code> dentro do <code>useEffect</code>?
+            <div>
+              a) Cancela a renderização &nbsp; b) Define estado inicial &nbsp;
+              c) Função de limpeza &nbsp; d) Nada
+            </div>
+          </li>
+          <li class="mb-3">
+            Quando um efeito com <code>[nome]</code> como dependência é
+            reexecutado?
+            <div>
+              a) Apenas no mount &nbsp; b) Em toda renderização &nbsp; c) Quando
+              <code>nome</code> mudar &nbsp; d) Nunca
+            </div>
+          </li>
+          <li class="mb-3">
+            Qual opção <strong>não</strong> respeita imutabilidade?
+            <div>
+              a) <code>setArr(prev =&gt; [...prev, 10])</code> &nbsp; b)
+              <code>arr.push(10); setArr(arr)</code> &nbsp; c)
+              <code>setObj(prev =&gt; ({...prev, a:1}))</code>
+            </div>
+          </li>
+        </ol>
+
+        <details class="solucao">
+          <summary>Mostrar gabarito</summary>
+          <ol>
+            <li>b) Em componentes de função e custom hooks</li>
+            <li>b) <code>setX(prev =&gt; prev + 1)</code></li>
+            <li>c) Função de limpeza</li>
+            <li>c) Quando <code>nome</code> mudar</li>
+            <li>b) <code>arr.push(10); setArr(arr)</code></li>
+          </ol>
+        </details>
+      </div>
+    </div>
+  </section>
+
+  <!-- 7. Exercícios (com solução escondida) -->
+  <section class="mb-5">
+    <h3 class="section-title with-icon">
+      <i class="fas fa-chalkboard-teacher"></i> 7. Exercícios
+    </h3>
+
+    <!-- Exercício 1 -->
+    <div class="desafio">
+      <h4>Exercício 1: Contador</h4>
+      <p>
+        <strong>Objetivo:</strong> criar um contador que aumente e diminua o
+        valor.
+      </p>
+      <ol>
+        <li>
+          Implemente o componente <code>Contador</code> com <code>+1</code> e
+          <code>-1</code>.
+        </li>
+        <li>Mostre o valor atual em um <code>&lt;p&gt;</code>.</li>
+        <li>Evite valores negativos (opcional).</li>
+      </ol>
+      <details class="solucao">
+        <summary>Mostrar solução</summary>
+        <pre><code class="language-jsx">import { useState } from 'react';
+
+export default function Contador() {
+  const [valor, setValor] = useState(0);
+
+  return (
+    &lt;div&gt;
+      &lt;p&gt;Valor: {valor}&lt;/p&gt;
+      &lt;button onClick={() =&gt; setValor(prev =&gt; prev + 1)}&gt;+1&lt;/button&gt;
+      &lt;button onClick={() =&gt; setValor(prev =&gt; Math.max(0, prev - 1))}&gt;-1&lt;/button&gt;
+    &lt;/div&gt;
+  );
+}</code></pre>
+      </details>
+    </div>
+
+    <!-- Exercício 2 -->
+    <div class="desafio">
+      <h4>Exercício 2: Relógio</h4>
+      <p><strong>Objetivo:</strong> exibir a hora atualizada a cada segundo.</p>
+      <ol>
+        <li>
+          Crie um <code>useEffect</code> com <code>setInterval</code> que
+          atualiza a hora.
+        </li>
+        <li>
+          Faça a limpeza com <code>clearInterval</code> no retorno do efeito.
+        </li>
+      </ol>
+      <details class="solucao">
+        <summary>Mostrar solução</summary>
         <pre><code class="language-jsx">import { useState, useEffect } from 'react';
 
 export default function Relogio() {
@@ -86,49 +421,213 @@ export default function Relogio() {
   }, []);
 
   return &lt;p&gt;{hora.toLocaleTimeString()}&lt;/p&gt;;
-}
-</code></pre>
-      </div>
+}</code></pre>
+      </details>
     </div>
-  </section>
 
-  <section class="mb-5">
-    <h3 class="section-title with-icon">
-      <i class="fas fa-check-circle"></i> 4. Resumo
-    </h3>
-    <div class="card mb-4">
-      <div class="card-body">
-        <ul>
-          <li><code>useState</code> controla dados mutáveis do componente.</li>
-          <li><code>useEffect</code> executa efeitos colaterais e permite
-            sincronizar o componente com o exterior.</li>
-        </ul>
-      </div>
-    </div>
-  </section>
-
-  <section class="mb-5">
-    <h3 class="section-title with-icon">
-      <i class="fas fa-chalkboard-teacher"></i> 5. Exercícios
-    </h3>
-
+    <!-- Exercício 3 -->
     <div class="desafio">
-      <h4>Exercício 1: Contador</h4>
-      <p><strong>Objetivo:</strong> criar um contador que aumente o valor ao clicar em um botão.</p>
+      <h4>Exercício 3: Campo de Texto Controlado</h4>
+      <p>
+        <strong>Objetivo:</strong> criar um input controlado e mostrar o texto
+        digitado.
+      </p>
       <ol>
-        <li>Implemente o componente <code>Contador</code> mostrado acima.</li>
-        <li>Adicione um segundo botão para diminuir o valor.</li>
-        <li>Exiba o valor atual na tela.</li>
+        <li>
+          Crie estado <code>texto</code> e ligue ao <code>value</code> do input.
+        </li>
+        <li>
+          Atualize com <code>onChange</code> e exiba o texto em um parágrafo.
+        </li>
+        <li>Mostre também a contagem de caracteres.</li>
       </ol>
+      <details class="solucao">
+        <summary>Mostrar solução</summary>
+        <pre><code class="language-jsx">import { useState } from 'react';
+
+export default function CampoTexto() {
+  const [texto, setTexto] = useState('');
+  return (
+    &lt;div&gt;
+      &lt;input value={texto} onChange={e =&gt; setTexto(e.target.value)} placeholder="Digite algo" /&gt;
+      &lt;p&gt;Você digitou: {texto || '(vazio)'}&lt;/p&gt;
+      &lt;p&gt;Caracteres: {texto.length}&lt;/p&gt;
+    &lt;/div&gt;
+  );
+}</code></pre>
+      </details>
     </div>
 
+    <!-- Exercício 4 -->
     <div class="desafio">
-      <h4>Exercício 2: Relógio</h4>
-      <p><strong>Objetivo:</strong> exibir a hora atualizada a cada segundo.</p>
+      <h4>Exercício 4: To-Do simples</h4>
+      <p>
+        <strong>Objetivo:</strong> adicionar itens em uma lista usando
+        <code>useState</code>.
+      </p>
       <ol>
-        <li>Use o componente <code>Relogio</code> mostrado anteriormente.</li>
-        <li>Altere o formato da hora utilizando <code>toLocaleTimeString</code>.</li>
+        <li>Crie um input e um botão “Adicionar”.</li>
+        <li>Guarde a lista em estado (array de strings).</li>
+        <li>
+          Liste os itens usando <code>map()</code> e uma
+          <code>key</code> estável.
+        </li>
       </ol>
+      <details class="solucao">
+        <summary>Mostrar solução</summary>
+        <pre><code class="language-jsx">import { useState } from 'react';
+
+export default function TodoSimples() {
+  const [texto, setTexto] = useState('');
+  const [itens, setItens] = useState([]);
+
+  function adicionar() {
+    const t = texto.trim();
+    if (!t) return;
+    setItens(prev =&gt; [...prev, t]);
+    setTexto('');
+  }
+
+  return (
+    &lt;div&gt;
+      &lt;input value={texto} onChange={e =&gt; setTexto(e.target.value)} placeholder="Nova tarefa" /&gt;
+      &lt;button onClick={adicionar}&gt;Adicionar&lt;/button&gt;
+      &lt;ul&gt;{itens.map((it, i) =&gt; &lt;li key={it + i}&gt;{it}&lt;/li&gt;)}&lt;/ul&gt;
+    &lt;/div&gt;
+  );
+}</code></pre>
+      </details>
+    </div>
+
+    <!-- Exercício 5 -->
+    <div class="desafio">
+      <h4>Exercício 5: Timer com Iniciar/Pausar/Reset</h4>
+      <p>
+        <strong>Objetivo:</strong> criar um cronômetro que conte segundos com
+        controle por botões.
+      </p>
+      <ol>
+        <li>
+          Estados: <code>segundos</code> e <code>rodando</code> (boolean).
+        </li>
+        <li>
+          Se <code>rodando</code> for <code>true</code>, inicie um
+          <code>setInterval</code> em um <code>useEffect</code>.
+        </li>
+        <li>Botões: Iniciar/Pausar/Reset.</li>
+      </ol>
+      <details class="solucao">
+        <summary>Mostrar solução</summary>
+        <pre><code class="language-jsx">import { useEffect, useState } from 'react';
+
+export default function Timer() {
+  const [segundos, setSegundos] = useState(0);
+  const [rodando, setRodando] = useState(false);
+
+  useEffect(() =&gt; {
+    if (!rodando) return;
+    const id = setInterval(() =&gt; setSegundos(prev =&gt; prev + 1), 1000);
+    return () =&gt; clearInterval(id);
+  }, [rodando]);
+
+  return (
+    &lt;div&gt;
+      &lt;p&gt;Tempo: {segundos}s&lt;/p&gt;
+      &lt;button onClick={() =&gt; setRodando(true)}&gt;Iniciar&lt;/button&gt;
+      &lt;button onClick={() =&gt; setRodando(false)}&gt;Pausar&lt;/button&gt;
+      &lt;button onClick={() =&gt; { setRodando(false); setSegundos(0); }}&gt;Reset&lt;/button&gt;
+    &lt;/div&gt;
+  );
+}</code></pre>
+      </details>
+    </div>
+
+    <!-- Exercício 6 -->
+    <div class="desafio">
+      <h4>Exercício 6: Tema Claro/Escuro com persistência</h4>
+      <p>
+        <strong>Objetivo:</strong> alternar tema e salvar no
+        <code>localStorage</code> usando <code>useEffect</code>.
+      </p>
+      <ol>
+        <li>Estado: <code>tema</code> = 'light' | 'dark'.</li>
+        <li>
+          Ao mudar o tema, salve em <code>localStorage</code> e aplique uma
+          classe no <code>body</code>.
+        </li>
+        <li>No <em>mount</em>, leia o valor salvo.</li>
+      </ol>
+      <details class="solucao">
+        <summary>Mostrar solução</summary>
+        <pre><code class="language-jsx">import { useEffect, useState } from 'react';
+
+export default function Tema() {
+  const [tema, setTema] = useState('light');
+
+  useEffect(() =&gt; {
+    const salvo = localStorage.getItem('tema');
+    if (salvo) setTema(salvo);
+  }, []);
+
+  useEffect(() =&gt; {
+    document.body.classList.toggle('dark', tema === 'dark');
+    localStorage.setItem('tema', tema);
+    return () =&gt; document.body.classList.remove('dark');
+  }, [tema]);
+
+  return (
+    &lt;div&gt;
+      &lt;p&gt;Tema atual: {tema}&lt;/p&gt;
+      &lt;button onClick={() =&gt; setTema(prev =&gt; prev === 'light' ? 'dark' : 'light')}&gt;
+        Alternar Tema
+      &lt;/button&gt;
+    &lt;/div&gt;
+  );
+}</code></pre>
+      </details>
+    </div>
+
+    <!-- Exercício 7 (Desafio) -->
+    <div class="desafio">
+      <h4>Exercício 7 (Desafio): Busca em API com Loading/Erro</h4>
+      <p>
+        <strong>Objetivo:</strong> exibir usuários de uma API simulando estados
+        de carregamento e erro.
+      </p>
+      <ol>
+        <li>
+          Estados: <code>dados</code>, <code>carregando</code>,
+          <code>erro</code>.
+        </li>
+        <li>
+          Faça <code>fetch</code> no <em>mount</em>; trate erro e finalize o
+          carregamento.
+        </li>
+        <li>Liste os nomes quando carregar.</li>
+      </ol>
+      <details class="solucao">
+        <summary>Mostrar solução</summary>
+        <pre><code class="language-jsx">import { useEffect, useState } from 'react';
+
+export default function Usuarios() {
+  const [dados, setDados] = useState([]);
+  const [carregando, setCarregando] = useState(true);
+  const [erro, setErro] = useState(null);
+
+  useEffect(() =&gt; {
+    let ativo = true;
+    fetch('https://jsonplaceholder.typicode.com/users')
+      .then(r =&gt; r.json())
+      .then(json =&gt; { if (ativo) { setDados(json); setCarregando(false); }})
+      .catch(e =&gt; { if (ativo) { setErro(e.message); setCarregando(false); }});
+    return () =&gt; { ativo = false; };
+  }, []);
+
+  if (carregando) return &lt;p&gt;Carregando...&lt;/p&gt;;
+  if (erro) return &lt;p&gt;Erro: {erro}&lt;/p&gt;;
+  return &lt;ul&gt;{dados.map(u =&gt; &lt;li key={u.id}&gt;{u.name}&lt;/li&gt;)}&lt;/ul&gt;;
+}</code></pre>
+      </details>
     </div>
   </section>
 </article>

--- a/aulas/react-introducao-componentes.html
+++ b/aulas/react-introducao-componentes.html
@@ -146,6 +146,7 @@ ReactDOM.render(
         <li><strong>Would you like to use Tailwind CSS? →</strong> <code>No</code></li>
         <li><strong>Would you like to use `src/` directory? →</strong> <code>No</code></li>
         <li><strong>Would you like to use App Router? (recommended) →</strong> <code>Yes</code></li>
+        <li><strong>Would you like to use Turbopack for the development server? →</strong> <code>No</code></li>
         <li><strong>Would you like to customize the default import alias? →</strong> <code>No</code></li>
       </ul>
 
@@ -158,10 +159,29 @@ npm run dev</code></pre>
     </div>
   </div>
 
-  <section class="mb-5">
-    <h3 class="section-title with-icon">
-      <i class="fas fa-puzzle-piece"></i> 6. Criando um Componente
-    </h3>
+  <div class="card mb-4">
+    <div class="card-body">
+      <h4>Arquivos importantes e scripts npm</h4>
+      <p>Após a criação do projeto, observe alguns arquivos gerados automaticamente:</p>
+      <ul>
+        <li><strong>package.json</strong> – registra dependências e scripts como <code>dev</code>, <code>build</code> e <code>start</code>.</li>
+        <li><strong>.gitignore</strong> – lista arquivos e pastas que não devem ser enviados ao Git.</li>
+      </ul>
+      <p>Os scripts mais utilizados são:</p>
+      <ul>
+        <li><code>npm run dev</code> – inicia o servidor de desenvolvimento com recarregamento automático.</li>
+        <li><code>npm run build</code> – cria uma versão otimizada para produção.</li>
+        <li><code>npm run start</code> – executa a aplicação após o <code>build</code>.</li>
+      </ul>
+    </div>
+  </div>
+
+</section>
+
+<section class="mb-5">
+  <h3 class="section-title with-icon">
+    <i class="fas fa-puzzle-piece"></i> 6. Criando um Componente
+  </h3>
 
     <!-- Introdução ao conceito -->
     <div class="card mb-4">

--- a/aulas/react-jsx-funcionais-props.html
+++ b/aulas/react-jsx-funcionais-props.html
@@ -1,4 +1,3 @@
-<!-- ==================== Aula React 2 ==================== -->
 <article class="lesson-content">
   <h2>
     <i class="fab fa-react"></i> React – JSX Avançado, Componentes e Props
@@ -16,153 +15,289 @@
       <li>✅ Componentes funcionais com arrow functions</li>
       <li>✅ Desestruturação e valores padrão de props</li>
       <li>✅ Composição e uso de <code>children</code></li>
-      <li>✅ Renderização de listas</li>
+      <li>✅ Renderização de listas e <code>key</code></li>
       <li>✅ Hierarquia de componentes e boas práticas</li>
+      <li>
+        ✅ <strong>Testes rápidos (quiz)</strong> e
+        <strong>exercícios com solução</strong>
+      </li>
     </ul>
   </div>
 
+  <!-- 1. JSX AVANÇADO -->
   <section class="mb-5">
     <h3 class="section-title with-icon">
       <i class="fas fa-code"></i> 1. Sintaxe Avançada do JSX
     </h3>
+
     <div class="card mb-4">
       <div class="card-body">
-        <p>
-          O JSX permite inserir expressões JavaScript dentro de chaves <code>{}</code> e agrupar elementos com <code>&lt;React.Fragment&gt;</code> ou <code>&lt;&gt;</code>.
-        </p>
+        <h4 class="mb-3">1.1 Regras fundamentais</h4>
+        <ul>
+          <li>
+            JSX precisa retornar <strong>um único elemento pai</strong>. Use
+            <code>&lt;&gt; ... &lt;/&gt;</code> (Fragment).
+          </li>
+          <li>Expressões JS vão entre chaves <code>{ }</code>.</li>
+          <li>Comentários em JSX: <code>{/* ... */}</code>.</li>
+          <li>
+            Atributos usam <strong>camelCase</strong>: <code>className</code>,
+            <code>onClick</code>, <code>tabIndex</code>.
+          </li>
+          <li>
+            <code>class</code> em HTML vira <code>className</code> em JSX.
+          </li>
+        </ul>
+
         <pre><code class="language-jsx">const nome = 'Ana';
 function Hello() {
   return (
     &lt;&gt;
       &lt;h1&gt;Olá, {nome}!&lt;/h1&gt;
-      {nome === 'Ana' && &lt;p&gt;Que bom ver você aqui!&lt;/p&gt;}
+      {/* Renderização condicional com &amp;&amp; */}
+      {nome === 'Ana' &amp;&amp; &lt;p&gt;Que bom ver você aqui!&lt;/p&gt;}
     &lt;/&gt;
   );
 }</code></pre>
+
+        <h4 class="mt-4 mb-3">1.2 Condicionais: &amp;&amp; vs. ternário</h4>
         <p>
-          Comentários em JSX ficam entre <code>{/* */}</code> e é comum usar o operador <code>&amp;&amp;</code> ou o ternário para renderização condicional.
+          <strong>Cuidado:</strong> valores como <code>0</code> são renderizados
+          na tela. Se sua expressão puder virar <code>0</code>, prefira o
+          ternário.
         </p>
+        <pre><code class="language-jsx">const pontos = 0;
+&lt;p&gt;
+  {/* Isto exibirá 0 na tela */}
+  {pontos &amp;&amp; 'Você tem pontos'}
+&lt;/p&gt;
+
+&lt;p&gt;
+  {/* Melhor: evita mostrar 0 */}
+  {pontos &gt; 0 ? 'Você tem pontos' : null}
+&lt;/p&gt;</code></pre>
+
+        <h4 class="mt-4 mb-3">1.3 Estilos inline e classes dinâmicas</h4>
+        <pre><code class="language-jsx">const ativo = true;
+const estilo = { padding: '8px', borderRadius: '6px' };
+
+&lt;button
+  style={estilo}
+  className={ativo ? 'btn btn-primary' : 'btn btn-outline'}
+&gt;
+  Botão
+&lt;/button&gt;</code></pre>
+
+        <h4 class="mt-4 mb-3">1.4 Atributos, strings e números</h4>
+        <pre><code class="language-jsx">const url = 'https://react.dev';
+const contagem = 3;
+
+&lt;a href={url} target="_blank" rel="noreferrer"&gt;Site&lt;/a&gt;
+&lt;p&gt;Você tem {contagem} novas mensagens.&lt;/p&gt;</code></pre>
+
+        <h4 class="mt-4 mb-3">1.5 Elementos autocontidos (self-closing)</h4>
+        <pre><code class="language-jsx">&lt;img src="/logo.png" alt="Logo" /&gt;
+&lt;input type="text" /&gt;</code></pre>
+
+        <div class="alert alert-info mt-4">
+          <strong>Segurança:</strong> JSX escapa valores por padrão (protege
+          contra XSS). Só use <code>dangerouslySetInnerHTML</code> quando souber
+          exatamente o que está fazendo.
+        </div>
       </div>
     </div>
   </section>
 
-
-
+  <!-- 2. COMPONENTES COM ARROW FUNCTIONS -->
   <section class="mb-5">
     <h3 class="section-title with-icon">
-      <i class="fas fa-puzzle-piece"></i> 2. Componentes Funcionais com Arrow Functions
+      <i class="fas fa-puzzle-piece"></i> 2. Componentes Funcionais com Arrow
+      Functions
     </h3>
+
     <div class="card mb-4">
       <div class="card-body">
         <p>
-          Podemos declarar componentes como funções tradicionais ou como <em>arrow functions</em>. Essa sintaxe costuma ser mais concisa e facilita a desestruturação de props.
+          Componentes devem ter nome em <strong>PascalCase</strong> e
+          <strong>retornar JSX</strong>.
         </p>
-        <pre><code class="language-jsx">const Botao = ({ texto }) =&gt; &lt;button&gt;{texto}&lt;/button&gt;;
+
+        <pre><code class="language-jsx">// Forma concisa (retorno implícito)
+const Botao = ({ texto }) =&gt; &lt;button&gt;{texto}&lt;/button&gt;;
+
+// Com bloco (retorno explícito)
+const BotaoGrande = ({ texto }) =&gt; {
+  return &lt;button className="btn btn-lg"&gt;{texto}&lt;/button&gt;;
+};
 
 export default function App() {
   return (
     &lt;div&gt;
       &lt;Botao texto="Salvar" /&gt;
       &lt;Botao texto="Cancelar" /&gt;
+      &lt;BotaoGrande texto="Continuar" /&gt;
     &lt;/div&gt;
   );
 }</code></pre>
-        <p>
-          Reutilizando o componente <code>Botao</code> com textos diferentes, mantemos o c&oacute;digo organizado e f&aacute;cil de manter.
-        </p>
+
+        <h4 class="mt-4 mb-2">
+          2.1 Desestruturação, valores padrão e rest props
+        </h4>
+        <pre><code class="language-jsx">const Alerta = ({ tipo = 'info', children, ...rest }) =&gt; {
+  const classe = `alert alert-${tipo}`;
+  return &lt;div className={classe} {...rest}&gt;{children}&lt;/div&gt;;
+};
+
+// Uso:
+&lt;Alerta tipo="warning" id="aviso"&gt;Cuidado!&lt;/Alerta&gt;
+&lt;Alerta&gt;Mensagem informativa&lt;/Alerta&gt;</code></pre>
+
+        <div class="alert alert-warning mt-3">
+          <strong>Erro comum:</strong> não esquecer de
+          <code>return</code> quando usar chaves <code>{'{'}{'}'}</code> no
+          corpo da arrow function.
+        </div>
       </div>
     </div>
   </section>
 
+  <!-- 3. PROPS -->
   <section class="mb-5">
     <h3 class="section-title with-icon">
       <i class="fas fa-paper-plane"></i> 3. Passando Dados com Props
     </h3>
+
     <div class="card mb-4">
       <div class="card-body">
         <p>
-          As <strong>props</strong> são parâmetros recebidos pelos componentes. Podemos desestruturá-las na assinatura e definir valores padrão.
+          Props são <strong>somente leitura</strong>. Você envia dados do
+          componente pai para o filho.
         </p>
-        <pre><code class="language-jsx">function Saudacao({ nome = 'Visitante' }) {
-  return &lt;h2&gt;Olá, {nome}!&lt;/h2&gt;;
+
+        <pre><code class="language-jsx">function Saudacao({ nome = 'Visitante', dia = 'hoje' }) {
+  return &lt;h2&gt;Olá, {nome}! Como vai {dia}?&lt;/h2&gt;;
 }
 
 export default function App() {
+  const nomes = ['Maria', 'João', 'Aline'];
   return (
     &lt;&gt;
-      &lt;Saudacao nome="Maria" /&gt;
-      &lt;Saudacao /&gt;
+      &lt;Saudacao nome="Maria" dia="essa manhã" /&gt;
+      &lt;Saudacao /&gt; {/* Visitante, hoje */}
+      {nomes.map(n =&gt; &lt;Saudacao key={n} nome={n} dia="agora" /&gt;)}
     &lt;/&gt;
   );
 }</code></pre>
-        <p>
-          Quando nenhuma prop é enviada, é utilizado o valor padrão <code>Visitante</code>.
-        </p>
+
+        <h4 class="mt-4 mb-2">3.1 Passando funções como props</h4>
+        <pre><code class="language-jsx">const BotaoAcao = ({ onAcao, children }) =&gt; (
+  &lt;button onClick={onAcao}&gt;{children}&lt;/button&gt;
+);
+
+export default function App() {
+  const dizerOi = () =&gt; alert('Oi!');
+  return &lt;BotaoAcao onAcao={dizerOi}&gt;Clique&lt;/BotaoAcao&gt;;
+}</code></pre>
       </div>
     </div>
   </section>
 
+  <!-- 4. CHILDREN / COMPOSIÇÃO -->
   <section class="mb-5">
     <h3 class="section-title with-icon">
       <i class="fas fa-layer-group"></i> 4. Composição com <code>children</code>
     </h3>
+
     <div class="card mb-4">
       <div class="card-body">
         <p>
-          Componentes podem envolver outros elementos usando a prop especial <code>children</code>. Dessa forma criamos blocos reutilizáveis de layout.
+          <code>children</code> permite envolver conteúdo e criar layouts
+          reutilizáveis.
         </p>
+
         <pre><code class="language-jsx">function Card({ children }) {
   return &lt;div className="card"&gt;{children}&lt;/div&gt;;
+}
+
+function CardHeader({ children }) {
+  return &lt;div className="card-header"&gt;{children}&lt;/div&gt;;
+}
+
+function CardBody({ children }) {
+  return &lt;div className="card-body"&gt;{children}&lt;/div&gt;;
 }
 
 export default function App() {
   return (
     &lt;Card&gt;
-      &lt;h2&gt;Título&lt;/h2&gt;
-      &lt;p&gt;Conteúdo enviado como children.&lt;/p&gt;
+      &lt;CardHeader&gt;&lt;h2&gt;Título&lt;/h2&gt;&lt;/CardHeader&gt;
+      &lt;CardBody&gt;&lt;p&gt;Conteúdo enviado como children.&lt;/p&gt;&lt;/CardBody&gt;
     &lt;/Card&gt;
   );
 }</code></pre>
-        <p>
-          Utilizando <code>children</code> é possível compor telas complexas de forma
-          simples e modular.
-        </p>
       </div>
     </div>
   </section>
 
+  <!-- 5. LISTAS E KEYS -->
   <section class="mb-5">
     <h3 class="section-title with-icon">
-      <i class="fas fa-list"></i> 5. Renderizando Listas
+      <i class="fas fa-list"></i> 5. Renderizando Listas (e a importância de
+      <code>key</code>)
     </h3>
+
     <div class="card mb-4">
       <div class="card-body">
         <p>
-          Para criar vários elementos a partir de um array, utilize o método <code>map()</code>.
+          Para criar vários elementos a partir de um array, utilize
+          <code>map()</code> e forneça uma <strong>key única e estável</strong>.
         </p>
+
         <pre><code class="language-jsx">const itens = ['React', 'Vue', 'Angular'];
+
 export default function App() {
   return (
     &lt;ul&gt;
-      {itens.map(framework => (
+      {itens.map(framework =&gt; (
         &lt;li key={framework}&gt;{framework}&lt;/li&gt;
       ))}
     &lt;/ul&gt;
   );
 }</code></pre>
+
+        <h4 class="mt-3">5.1 Objetos com IDs</h4>
+        <pre><code class="language-jsx">const cursos = [
+  { id: 101, nome: 'Lógica de Programação' },
+  { id: 102, nome: 'Front-end' },
+  { id: 103, nome: 'Back-end' },
+];
+
+export default function App() {
+  return (
+    &lt;ol&gt;
+      {cursos.map(c =&gt; &lt;li key={c.id}&gt;{c.nome}&lt;/li&gt;)}
+    &lt;/ol&gt;
+  );
+}</code></pre>
+
+        <div class="alert alert-warning mt-3">
+          <strong>Atenção:</strong> usar o índice do array como
+          <code>key</code> pode causar bugs em reordenações/remoções. Prefira um
+          identificador estável (ex.: <code>id</code> do item).
+        </div>
       </div>
     </div>
   </section>
 
+  <!-- 6. HIERARQUIA E BOAS PRÁTICAS -->
   <section class="mb-5">
     <h3 class="section-title with-icon">
-      <i class="fas fa-sitemap"></i> 6. Hierarquia de Componentes
+      <i class="fas fa-sitemap"></i> 6. Hierarquia de Componentes e Boas
+      Práticas
     </h3>
+
     <div class="card mb-4">
       <div class="card-body">
-        <p>
-          Em React, os componentes se organizam em uma <strong>árvore</strong>. Componentes "pais" podem renderizar componentes "filhos" e transmitir dados através das <strong>props</strong>.
-        </p>
         <pre><code class="language-jsx">function Header() {
   return &lt;h1&gt;Meu App&lt;/h1&gt;;
 }
@@ -179,33 +314,127 @@ export default function App() {
     &lt;/Layout&gt;
   );
 }</code></pre>
-        <p>
-          Manter uma hierarquia clara facilita a manutenção e ajuda a evitar o <em>props drilling</em>, quando muitas props precisam atravessar vários níveis da árvore.
-        </p>
+
+        <h4 class="mt-4 mb-2">Boas práticas:</h4>
+        <ul>
+          <li>Quebre componentes grandes em menores e reutilizáveis.</li>
+          <li>
+            Evite <em>props drilling</em> (passar props por muitos níveis). Em
+            breve veremos Context API.
+          </li>
+          <li>
+            Nomeie props de eventos com <code>onAlgo</code> e handlers com
+            <code>handleAlgo</code>.
+          </li>
+          <li>
+            Prefira dados imutáveis (não mutar arrays/objetos diretamente).
+          </li>
+        </ul>
       </div>
     </div>
   </section>
 
+  <!-- 7. TESTES RÁPIDOS (QUIZ) -->
   <section class="mb-5">
     <h3 class="section-title with-icon">
-      <i class="fas fa-chalkboard-teacher"></i> 7. Exercícios
+      <i class="fas fa-check-circle"></i> 7. Testes Rápidos (Quiz)
+    </h3>
+
+    <div class="card mb-4">
+      <div class="card-body">
+        <ol>
+          <li class="mb-3">
+            Em JSX, qual atributo substitui <code>class</code> do HTML?
+            <div>
+              a) <code>classname</code> &nbsp; b) <code>className</code> &nbsp;
+              c) <code>class_html</code> &nbsp; d) <code>class()</code>
+            </div>
+          </li>
+          <li class="mb-3">
+            Onde colocamos expressões JavaScript no JSX?
+            <div>
+              a) Entre parênteses &nbsp; b) Entre colchetes &nbsp; c) Entre
+              chaves &nbsp; d) Entre aspas
+            </div>
+          </li>
+          <li class="mb-3">
+            Qual a melhor <code>key</code> para uma lista de objetos?
+            <div>
+              a) Índice do array &nbsp; b) <code>Math.random()</code> &nbsp; c)
+              Um <code>id</code> estável &nbsp; d) O texto exibido
+            </div>
+          </li>
+          <li class="mb-3">
+            O que <strong>não</strong> é recomendado fazer com props?
+            <div>
+              a) Desestruturar &nbsp; b) Definir valor padrão &nbsp; c)
+              Modificar dentro do filho &nbsp; d) Passar função como prop
+            </div>
+          </li>
+          <li class="mb-3">
+            Qual opção <strong>evita</strong> renderizar o número
+            <code>0</code> quando não há pontos?
+            <pre><code class="language-jsx">const pontos = 0;
+{/* escolha a melhor linha para dentro do JSX */}
+A) {pontos &amp;&amp; 'Você tem pontos'}
+B) {pontos &gt; 0 ? 'Você tem pontos' : null}</code></pre>
+          </li>
+        </ol>
+
+        <details class="solucao">
+          <summary>Mostrar gabarito</summary>
+          <ol>
+            <li>b) <code>className</code></li>
+            <li>c) Entre chaves <code>{'{'}{'}'}</code></li>
+            <li>c) Um <code>id</code> estável</li>
+            <li>c) Modificar dentro do filho</li>
+            <li>
+              B) <code>{'{'}pontos &gt; 0 ? 'Você tem pontos' : null{'}'}</code>
+            </li>
+          </ol>
+        </details>
+      </div>
+    </div>
+  </section>
+
+  <!-- 8. EXERCÍCIOS PRÁTICOS COM SOLUÇÃO -->
+  <section class="mb-5">
+    <h3 class="section-title with-icon">
+      <i class="fas fa-chalkboard-teacher"></i> 8. Exercícios Práticos
     </h3>
 
     <!-- Exercício 1 -->
     <div class="desafio">
       <h4>Exercício 1: Card Componente</h4>
       <p>
-        <strong>Objetivo:</strong> criar um componente reutilizável que utilize a
-        prop <code>children</code>.
+        <strong>Objetivo:</strong> criar um componente reutilizável que utilize
+        a prop <code>children</code>.
       </p>
       <ol>
-        <li>Implemente o componente <code>Card</code> como mostrado na aula.</li>
         <li>
-          Use-o no <code>App</code> para envolver um título e um parágrafo de
-          sua escolha.
+          Implemente o componente <code>Card</code> com uma borda e padding.
+        </li>
+        <li>
+          Use-o no <code>App</code> para envolver um título e um parágrafo.
         </li>
         <li>Confira o resultado no navegador.</li>
       </ol>
+      <details class="solucao">
+        <summary>Mostrar solução</summary>
+        <pre><code class="language-jsx">function Card({ children }) {
+  const estilo = { border: '1px solid #ddd', padding: '12px', borderRadius: '8px' };
+  return &lt;div style={estilo}&gt;{children}&lt;/div&gt;;
+}
+
+export default function App() {
+  return (
+    &lt;Card&gt;
+      &lt;h3&gt;Título do Card&lt;/h3&gt;
+      &lt;p&gt;Este é um conteúdo qualquer.&lt;/p&gt;
+    &lt;/Card&gt;
+  );
+}</code></pre>
+      </details>
     </div>
 
     <!-- Exercício 2 -->
@@ -217,9 +446,21 @@ export default function App() {
       </p>
       <ol>
         <li>Crie um array com três ou mais strings.</li>
-        <li>Utilize <code>map()</code> para gerar os elementos <code>li</code>.</li>
-        <li>Não esqueça de definir uma <code>key</code> única para cada item.</li>
+        <li>Use <code>map()</code> para gerar os elementos <code>li</code>.</li>
+        <li>Defina uma <code>key</code> única para cada item.</li>
       </ol>
+      <details class="solucao">
+        <summary>Mostrar solução</summary>
+        <pre><code class="language-jsx">const linguagens = ['JavaScript', 'Python', 'Go', 'Rust'];
+
+export default function App() {
+  return (
+    &lt;ul&gt;
+      {linguagens.map(lang =&gt; &lt;li key={lang}&gt;{lang}&lt;/li&gt;)}
+    &lt;/ul&gt;
+  );
+}</code></pre>
+      </details>
     </div>
 
     <!-- Exercício 3 -->
@@ -230,11 +471,185 @@ export default function App() {
         saudações personalizadas.
       </p>
       <ol>
-        <li>Reaproveite o componente <code>Saudacao</code> apresentado.</li>
+        <li>Reaproveite o componente <code>Saudacao</code>.</li>
         <li>Renderize-o enviando nomes diferentes como prop.</li>
         <li>Verifique que cada instância exibe a mensagem correta.</li>
       </ol>
+      <details class="solucao">
+        <summary>Mostrar solução</summary>
+        <pre><code class="language-jsx">function Saudacao({ nome = 'Visitante' }) {
+  return &lt;h2&gt;Olá, {nome}!&lt;/h2&gt;;
+}
+
+export default function App() {
+  const nomes = ['Ana', 'Bruno', 'Carla'];
+  return (
+    &lt;&gt;
+      {nomes.map(n =&gt; &lt;Saudacao key={n} nome={n} /&gt;)}
+      &lt;Saudacao /&gt; {/* Visitante */}
+    &lt;/&gt;
+  );
+}</code></pre>
+      </details>
+    </div>
+
+    <!-- Exercício 4 -->
+    <div class="desafio">
+      <h4>Exercício 4: Botão de Ação</h4>
+      <p>
+        <strong>Objetivo:</strong> passar uma função como prop e reagir a um
+        clique.
+      </p>
+      <ol>
+        <li>
+          Crie um componente <code>BotaoAcao</code> que recebe
+          <code>onAcao</code> e <code>children</code>.
+        </li>
+        <li>
+          No <code>App</code>, defina uma função que exibe um
+          <code>alert</code>.
+        </li>
+        <li>Passe essa função para o botão e teste.</li>
+      </ol>
+      <details class="solucao">
+        <summary>Mostrar solução</summary>
+        <pre><code class="language-jsx">const BotaoAcao = ({ onAcao, children }) =&gt; (
+  &lt;button onClick={onAcao}&gt;{children}&lt;/button&gt;
+);
+
+export default function App() {
+  const handleClick = () =&gt; alert('Ação executada!');
+  return &lt;BotaoAcao onAcao={handleClick}&gt;Clique Aqui&lt;/BotaoAcao&gt;;
+}</code></pre>
+      </details>
+    </div>
+
+    <!-- Exercício 5 -->
+    <div class="desafio">
+      <h4>Exercício 5: Lista de Objetos com ID</h4>
+      <p>
+        <strong>Objetivo:</strong> renderizar uma lista de objetos usando
+        <code>key</code> estável.
+      </p>
+      <ol>
+        <li>
+          Crie um array de objetos com <code>id</code> e <code>nome</code>.
+        </li>
+        <li>
+          Mostre a lista em um <code>&lt;ol&gt;</code> usando
+          <code>key={obj.id}</code>.
+        </li>
+      </ol>
+      <details class="solucao">
+        <summary>Mostrar solução</summary>
+        <pre><code class="language-jsx">const alunos = [
+  { id: 1, nome: 'Paula' },
+  { id: 2, nome: 'Rafael' },
+  { id: 3, nome: 'Nina' },
+];
+
+export default function App() {
+  return (
+    &lt;ol&gt;
+      {alunos.map(a =&gt; &lt;li key={a.id}&gt;{a.nome}&lt;/li&gt;)}
+    &lt;/ol&gt;
+  );
+}</code></pre>
+      </details>
+    </div>
+
+    <!-- Exercício 6 -->
+    <div class="desafio">
+      <h4>Exercício 6: Card com variação de estilo por prop</h4>
+      <p><strong>Objetivo:</strong> alterar classe/estilo conforme uma prop.</p>
+      <ol>
+        <li>
+          Crie um componente <code>Badge</code> que recebe
+          <code>tipo</code> (<code>success</code> | <code>warning</code> |
+          <code>info</code>).
+        </li>
+        <li>Mude a classe do elemento com base em <code>tipo</code>.</li>
+      </ol>
+      <details class="solucao">
+        <summary>Mostrar solução</summary>
+        <pre><code class="language-jsx">const Badge = ({ tipo = 'info', children }) =&gt; {
+  const classe = `badge badge-${tipo}`;
+  return &lt;span className={classe}&gt;{children}&lt;/span&gt;;
+};
+
+export default function App() {
+  return (
+    &lt;p&gt;
+      &lt;Badge tipo="success"&gt;OK&lt;/Badge&gt;{' '}
+      &lt;Badge tipo="warning"&gt;Atenção&lt;/Badge&gt;{' '}
+      &lt;Badge&gt;Info&lt;/Badge&gt;
+    &lt;/p&gt;
+  );
+}</code></pre>
+      </details>
+    </div>
+
+    <!-- Exercício 7 -->
+    <div class="desafio">
+      <h4>Exercício 7 (Desafio): Composição com Header e Body</h4>
+      <p>
+        <strong>Objetivo:</strong> praticar <code>children</code> criando
+        <code>Card</code>, <code>CardHeader</code> e <code>CardBody</code>.
+      </p>
+      <ol>
+        <li>Implemente os três componentes.</li>
+        <li>Use-os juntos para montar um card com título e conteúdo.</li>
+      </ol>
+      <details class="solucao">
+        <summary>Mostrar solução</summary>
+        <pre><code class="language-jsx">function Card({ children }) {
+  return &lt;div className="card"&gt;{children}&lt;/div&gt;;
+}
+function CardHeader({ children }) {
+  return &lt;div className="card-header"&gt;{children}&lt;/div&gt;;
+}
+function CardBody({ children }) {
+  return &lt;div className="card-body"&gt;{children}&lt;/div&gt;;
+}
+
+export default function App() {
+  return (
+    &lt;Card&gt;
+      &lt;CardHeader&gt;&lt;h3&gt;Título&lt;/h3&gt;&lt;/CardHeader&gt;
+      &lt;CardBody&gt;&lt;p&gt;Texto do corpo do card.&lt;/p&gt;&lt;/CardBody&gt;
+    &lt;/Card&gt;
+  );
+}</code></pre>
+      </details>
     </div>
   </section>
 
+  <!-- 9. REFERÊNCIAS RÁPIDAS -->
+  <section class="mb-5">
+    <h3 class="section-title with-icon">
+      <i class="fas fa-book"></i> 9. Referências Rápidas (Resumo)
+    </h3>
+    <div class="card mb-4">
+      <div class="card-body">
+        <ul>
+          <li>
+            JSX: um pai, expressões em <code>{'{'}{'}'}</code>,
+            <code>className</code>, eventos em camelCase.
+          </li>
+          <li>
+            Props: somente leitura, desestruturação e valores padrão na
+            assinatura.
+          </li>
+          <li><code>children</code>: composição e layouts reutilizáveis.</li>
+          <li>
+            Listas: use <code>map()</code> e <code>key</code> estável (evite
+            índice).
+          </li>
+          <li>
+            Condicionais: prefira ternário para evitar mostrar <code>0</code>.
+          </li>
+        </ul>
+      </div>
+    </div>
+  </section>
 </article>

--- a/aulas/react-jsx-funcionais-props.html
+++ b/aulas/react-jsx-funcionais-props.html
@@ -17,6 +17,7 @@
       <li>✅ Desestruturação e valores padrão de props</li>
       <li>✅ Composição e uso de <code>children</code></li>
       <li>✅ Renderização de listas</li>
+      <li>✅ Hierarquia de componentes e boas práticas</li>
     </ul>
   </div>
 
@@ -155,7 +156,39 @@ export default function App() {
 
   <section class="mb-5">
     <h3 class="section-title with-icon">
-      <i class="fas fa-chalkboard-teacher"></i> 6. Exercícios
+      <i class="fas fa-sitemap"></i> 6. Hierarquia de Componentes
+    </h3>
+    <div class="card mb-4">
+      <div class="card-body">
+        <p>
+          Em React, os componentes se organizam em uma <strong>árvore</strong>. Componentes "pais" podem renderizar componentes "filhos" e transmitir dados através das <strong>props</strong>.
+        </p>
+        <pre><code class="language-jsx">function Header() {
+  return &lt;h1&gt;Meu App&lt;/h1&gt;;
+}
+
+function Layout({ children }) {
+  return &lt;div className="layout"&gt;{children}&lt;/div&gt;;
+}
+
+export default function App() {
+  return (
+    &lt;Layout&gt;
+      &lt;Header /&gt;
+      &lt;p&gt;Conteúdo principal&lt;/p&gt;
+    &lt;/Layout&gt;
+  );
+}</code></pre>
+        <p>
+          Manter uma hierarquia clara facilita a manutenção e ajuda a evitar o <em>props drilling</em>, quando muitas props precisam atravessar vários níveis da árvore.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section class="mb-5">
+    <h3 class="section-title with-icon">
+      <i class="fas fa-chalkboard-teacher"></i> 7. Exercícios
     </h3>
 
     <!-- Exercício 1 -->

--- a/index.html
+++ b/index.html
@@ -116,16 +116,16 @@
               <i class="fab fa-react"></i> JSX, Componentes Funcionais e Props
             </a>
           </li>
-          <li>
+          <!-- <li>
             <a href="#" onclick="loadContent('react-estado-hooks-basicos')">
               <i class="fab fa-react"></i> Estado e Hooks Básicos – useState e useEffect
             </a>
-          </li>
-          <li>
+          </li> -->
+          <!-- <li>
             <a href="#" onclick="loadContent('react-componentizacao-avancada')">
               <i class="fab fa-react"></i> Componentização Avançada e Composição de Componentes
             </a>
-          </li>
+          </li> -->
         </ul>
 
         <!-- Seção de recursos -->

--- a/index.html
+++ b/index.html
@@ -111,11 +111,21 @@
               Primeiros Componentes
             </a>
           </li>
-          <!-- <li>
+          <li>
             <a href="#" onclick="loadContent('react-jsx-funcionais-props')">
-              <i class="fab fa-react"></i> JSX Avançado e Props
+              <i class="fab fa-react"></i> JSX, Componentes Funcionais e Props
             </a>
-          </li> -->
+          </li>
+          <li>
+            <a href="#" onclick="loadContent('react-estado-hooks-basicos')">
+              <i class="fab fa-react"></i> Estado e Hooks Básicos – useState e useEffect
+            </a>
+          </li>
+          <li>
+            <a href="#" onclick="loadContent('react-componentizacao-avancada')">
+              <i class="fab fa-react"></i> Componentização Avançada e Composição de Componentes
+            </a>
+          </li>
         </ul>
 
         <!-- Seção de recursos -->


### PR DESCRIPTION
## Summary
- expand introductory React lesson with Turbopack prompt, `package.json`, `.gitignore` and npm scripts
- enrich JSX and props lesson with hierarchy section and best-practice bullet
- add new lessons on state/useEffect and advanced component composition
- expose new React lessons in navigation menu

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/apostila-webdev/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68977b8ba4d4832e80e1ce823b17de3d